### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"


### PR DESCRIPTION
Changes:
- Add Dependabot config file that checks Github Actions workflows every Monday at 03:00

Related to equinor/mad-project-rep#6293