### PR TITLE
fix: Replace deprecated THREE.Clock with performance.now()

### DIFF
--- a/src/components/Annotations/AutoUpdate.tsx
+++ b/src/components/Annotations/AutoUpdate.tsx
@@ -8,15 +8,15 @@ const samples = 8;
 const supersample = 1;
 
 export const AutoUpdate = ({ maxVisible }: { maxVisible: number }) => {
-  const { scene, camera, pointer, clock } = useThree();
+  const { scene, camera, pointer } = useThree();
 
   const passes = useMemo(
     () => [
       new RenderPass(scene, camera),
-      new AnnotationsPass(camera, clock, pointer, maxVisible),
+      new AnnotationsPass(camera, pointer, maxVisible),
       new OutputPass(),
     ],
-    [scene, camera, clock, pointer, maxVisible],
+    [scene, camera, pointer, maxVisible],
   );
 
   return (

--- a/src/components/Annotations/update-annotations.ts
+++ b/src/components/Annotations/update-annotations.ts
@@ -1,4 +1,4 @@
-import { Clock, PerspectiveCamera, Vector3 } from 'three';
+import { PerspectiveCamera, Vector3 } from 'three';
 
 import RBush from 'rbush';
 import { PI, Vec2, Vec3, clamp, edgeOfRectangle } from '../../sdk';
@@ -15,6 +15,11 @@ const transitionRate = 5;
 const position = new Vector3();
 
 let prevTime = 0;
+
+/** Get elapsed time in seconds, replacing deprecated THREE.Clock */
+function getElapsedTime(): number {
+  return performance.now() / 1000;
+}
 let _transform: string, _opacity: string, _zIndex: string;
 let x: number, y: number;
 
@@ -112,10 +117,10 @@ function setTransition(
 export function preprocessInstances(
   instances: AnnotationInstance[],
   camera: PerspectiveCamera,
-  clock: Clock,
   maxVisible: number,
 ) {
-  const deltaTime = clock.elapsedTime - prevTime;
+  const now = getElapsedTime();
+  const deltaTime = now - prevTime;
   const halfFovRad = (camera.fov * PI) / 360;
 
   let nInViewSpace = 0;
@@ -283,7 +288,7 @@ export function preprocessInstances(
     }
   });
 
-  prevTime = clock.elapsedTime;
+  prevTime = now;
 
   inViewspace.sort((a, b) => b.rank - a.rank);
 

--- a/src/rendering/passes/AnnotationsPass.ts
+++ b/src/rendering/passes/AnnotationsPass.ts
@@ -1,7 +1,6 @@
 import {
   Camera,
   CanvasTexture,
-  Clock,
   createCanvasElement,
   DataTexture,
   FloatType,
@@ -47,7 +46,6 @@ const _cursor: [number, number] = [0, 0];
 export class AnnotationsPass extends Pass {
   maxVisible: number;
   camera: PerspectiveCamera;
-  clock: Clock;
   pointer: Vector2;
   ctx: CanvasRenderingContext2D;
   overlayTexture: CanvasTexture | null = null;
@@ -86,13 +84,11 @@ export class AnnotationsPass extends Pass {
 
   constructor(
     camera: Camera,
-    clock: Clock,
     pointer: Vector2,
     maxVisible: number = 100,
   ) {
     super();
     this.camera = camera as PerspectiveCamera;
-    this.clock = clock;
     this.pointer = pointer;
     this.maxVisible = maxVisible;
 
@@ -426,7 +422,6 @@ export class AnnotationsPass extends Pass {
     const visibleInstances = preprocessInstances(
       instances,
       camera,
-      this.clock,
       maxVisible,
     );
 

--- a/src/storybook/examples/OITRenderPass.example.stories.tsx
+++ b/src/storybook/examples/OITRenderPass.example.stories.tsx
@@ -215,14 +215,14 @@ const Example = (args: ExampleProps) => {
     const base = args.oitEnabled
       ? new OITRenderPass(scene, camera)
       : new RenderPass(scene, camera);
-    const annotations = new AnnotationsPass(camera, clock, pointer, 1000);
+    const annotations = new AnnotationsPass(camera, pointer, 1000);
     // All anti-aliasing is now built into OITRenderPass (temporal / SMAA), driven
     // by the antialias sync effect below; supersampling is a separate, resolution-
     // based control on the pipeline. So no AA post-pass is added here.
     const list: Pass[] = [base, annotations, new OutputPass()];
 
     return list;
-  }, [scene, camera, clock, pointer, args.oitEnabled]);
+  }, [scene, camera, pointer, args.oitEnabled]);
 
   const oitPass = passes[0] instanceof OITRenderPass ? passes[0] : null;
 


### PR DESCRIPTION
## Summary

Replaces usage of the deprecated `THREE.Clock` with `performance.now()` for elapsed time tracking, as requested in #207.

### Problem
The `Clock` class in Three.js is deprecated. The codebase was using `THREE.Clock` in `AnnotationsPass` and passing it through to `preprocessInstances` for delta time calculations.

### Fix
- Added a `getElapsedTime()` helper function in `update-annotations.ts` that uses `performance.now() / 1000` for seconds-based timing
- Removed `Clock` import from both `AnnotationsPass.ts` and `update-annotations.ts`
- Removed `clock` property from `AnnotationsPass` class and constructor parameter
- Removed `clock` parameter from `preprocessInstances` function signature
- Updated all call sites (`AutoUpdate.tsx`, `OITRenderPass.example.stories.tsx`) to remove the clock argument

### Behavior
The elapsed time calculation remains functionally equivalent: `performance.now() / 1000` provides the same monotonically increasing seconds-based timer that `clock.elapsedTime` provided.

Fixes #207