### PR TITLE
fix: debug release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,4 +151,4 @@ jobs:
             exit 1
           fi
 
-          npm publish "${tarballs[0]}" --access public --ignore-scripts --provenance
+          npm publish "./${tarballs[0]}" --access public --ignore-scripts --provenance


### PR DESCRIPTION
This pull request makes a small update to the npm publish command in the release workflow. The change ensures that the path to the tarball is explicitly relative, which can help avoid issues with file resolution during publishing.

Time criticality for PR: Low, but releases won't work until merged. After merge, a new release PR will be generated.